### PR TITLE
DAC6-3429: Add identifier-based auth

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -33,4 +33,6 @@ class AppConfig @Inject() (
 
   val bearerToken: String => String = (serviceName: String) => config.get[String](s"microservice.services.$serviceName.bearer-token")
   val environment: String => String = (serviceName: String) => config.get[String](s"microservice.services.$serviceName.environment")
+
+  val enrolmentKey: String => String = (serviceName: String) => config.get[String](s"enrolmentKeys.$serviceName.key")
 }

--- a/app/controllers/auth/IdentifierAuthAction.scala
+++ b/app/controllers/auth/IdentifierAuthAction.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.auth
+
+import com.google.inject.ImplementedBy
+import config.AppConfig
+import play.api.http.Status.UNAUTHORIZED
+import play.api.mvc.Results.Status
+import play.api.mvc._
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class IdentifierAuthActionImpl @Inject() (
+  override val authConnector: AuthConnector,
+  val parser: BodyParsers.Default,
+  config: AppConfig
+)(implicit val executionContext: ExecutionContext)
+    extends IdentifierAuthAction
+    with AuthorisedFunctions {
+
+  val enrolmentKey: String      = config.enrolmentKey("cbc")
+  val nonUkEnrolmentKey: String = config.enrolmentKey("cbcNonUK")
+  val agentEnrolmentKey: String = config.enrolmentKey("agent")
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+
+    authorised(Enrolment(enrolmentKey) or Enrolment(nonUkEnrolmentKey) or Enrolment(agentEnrolmentKey))
+      .retrieve(Retrievals.authorisedEnrolments and Retrievals.affinityGroup) {
+        case Enrolments(enrolments) ~ Some(Agent) if enrolments.exists(_.key.equals(agentEnrolmentKey)) =>
+          val arn =
+            for {
+              enrolment <- enrolments.find(_.key.equals(agentEnrolmentKey))
+              arn       <- enrolment.getIdentifier("AgentReferenceNumber")
+            } yield arn.value
+
+          block(IdentifierRequest(request, Agent, arn))
+        case Enrolments(enrolments) ~ Some(Organisation) if enrolments.exists(_.key.equals(enrolmentKey)) =>
+          block(IdentifierRequest(request, Organisation))
+        case Enrolments(enrolments) ~ Some(Organisation) if enrolments.exists(_.key.equals(nonUkEnrolmentKey)) =>
+          block(IdentifierRequest(request, Organisation))
+        case _ ~ _ => Future.successful(Status(UNAUTHORIZED))
+      } recover { case _: NoActiveSession =>
+      Status(UNAUTHORIZED)
+    }
+  }
+}
+
+@ImplementedBy(classOf[IdentifierAuthActionImpl])
+trait IdentifierAuthAction extends ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]

--- a/app/controllers/auth/IdentifierRequest.scala
+++ b/app/controllers/auth/IdentifierRequest.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.auth
+
+import play.api.mvc.{Request, WrappedRequest}
+import uk.gov.hmrc.auth.core.AffinityGroup
+
+case class IdentifierRequest[+A](request: Request[A], affinityGroup: AffinityGroup, arn: Option[String] = None) extends WrappedRequest[A](request) {}

--- a/app/models/audit/SubscriptionAuditDetails.scala
+++ b/app/models/audit/SubscriptionAuditDetails.scala
@@ -20,6 +20,7 @@ import models.subscription.CreateSubscriptionResponse
 import models.subscription.common.{PrimaryContact, SecondaryContact}
 import models.subscription.request.CreateSubscriptionForCBCRequest
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.auth.core.AffinityGroup
 
 final case class SubscriptionAuditDetails(
   idType: String,
@@ -28,7 +29,8 @@ final case class SubscriptionAuditDetails(
   primaryContact: PrimaryContact,
   response: SubscriptionResponseAuditDetails,
   tradingName: Option[String],
-  secondaryContact: Option[SecondaryContact]
+  secondaryContact: Option[SecondaryContact],
+  userType: Option[AffinityGroup] = None
 )
 
 object SubscriptionAuditDetails {
@@ -36,7 +38,8 @@ object SubscriptionAuditDetails {
 
   def fromSubscriptionRequestAndResponse(
     request: CreateSubscriptionForCBCRequest,
-    response: CreateSubscriptionResponse
+    response: CreateSubscriptionResponse,
+    userType: AffinityGroup
   ): SubscriptionAuditDetails = {
     val requestDetail              = request.createSubscriptionForCBCRequest.requestDetail
     val createSubscriptionResponse = response.createSubscriptionForCBCResponse
@@ -52,7 +55,8 @@ object SubscriptionAuditDetails {
         createSubscriptionResponse.responseCommon.processingDate
       ),
       requestDetail.tradingName,
-      requestDetail.secondaryContact
+      requestDetail.secondaryContact,
+      Some(userType)
     )
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,6 +69,11 @@ auditing {
   enabled = true
 }
 
+enrolmentKeys {
+  cbc.key = "HMRC-CBC-ORG"
+  cbcNonUK.key = "HMRC-CBC-NONUK-ORG"
+  agent.key = "HMRC-AS-AGENT"
+}
 
 microservice {
 

--- a/test/controllers/SubscriptionControllerSpec.scala
+++ b/test/controllers/SubscriptionControllerSpec.scala
@@ -18,14 +18,13 @@ package controllers
 
 import base.SpecBase
 import connectors.SubscriptionConnector
-import controllers.auth.{AuthAction, FakeAuthAction}
+import controllers.auth.{FakeIdentifierAuthAction, IdentifierAuthAction}
 import generators.Generators
 import models.audit.{AuditType, SubscriptionAuditDetails}
-import models.subscription.{CreateSubscriptionResponse, DisplaySubscriptionForCBCRequest}
 import models.subscription.request.CreateSubscriptionForCBCRequest
+import models.subscription.{CreateSubscriptionResponse, DisplaySubscriptionForCBCRequest}
 import models.{ErrorDetail, ErrorDetails, SafeId, SourceFaultDetail}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.{eq => mEq}
+import org.mockito.ArgumentMatchers.{any, eq => mEq}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -35,7 +34,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.audit.AuditService
-import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import java.time.ZonedDateTime
@@ -54,7 +53,7 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
       bind[SubscriptionConnector].toInstance(mockSubscriptionConnector),
       bind[AuthConnector].toInstance(mockAuthConnector),
       bind[AuditService].toInstance(mockAuditService),
-      bind[AuthAction].to[FakeAuthAction]
+      bind[IdentifierAuthAction].to[FakeIdentifierAuthAction]
     )
     .build()
 
@@ -66,7 +65,7 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
       "should create a subscription and send an audit event" in {
         forAll { (subscriptionRequest: CreateSubscriptionForCBCRequest, subscriptionResponse: CreateSubscriptionResponse) =>
           val subscriptionAuditDetails = SubscriptionAuditDetails
-            .fromSubscriptionRequestAndResponse(subscriptionRequest, subscriptionResponse)
+            .fromSubscriptionRequestAndResponse(subscriptionRequest, subscriptionResponse, AffinityGroup.Organisation)
 
           val subscriptionEventDetail = Json.toJson(subscriptionAuditDetails)
 

--- a/test/controllers/auth/FakeAuthAction.scala
+++ b/test/controllers/auth/FakeAuthAction.scala
@@ -18,6 +18,7 @@ package controllers.auth
 
 import com.google.inject.Inject
 import play.api.mvc.{BodyParsers, Request, Result}
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -31,4 +32,13 @@ class FakeAuthAction @Inject() (
     block: Request[A] => Future[Result]
   ): Future[Result] =
     block(request)
+}
+
+class FakeIdentifierAuthAction @Inject() (
+  val parser: BodyParsers.Default
+)(implicit val executionContext: ExecutionContext)
+    extends IdentifierAuthAction {
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
+    block(IdentifierRequest(request, Organisation))
 }

--- a/test/controllers/auth/IdentifierAuthActionSpec.scala
+++ b/test/controllers/auth/IdentifierAuthActionSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.auth
+
+import org.apache.pekko.util.Timeout
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status.{OK, UNAUTHORIZED}
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.{Action, AnyContent, InjectedController}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.status
+import play.api.{Application, Configuration}
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.{~, Retrieval}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
+class IdentifierAuthActionSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar {
+
+  type RetrievalType = Enrolments ~ Option[AffinityGroup]
+
+  class Harness(authAction: IdentifierAuthAction) extends InjectedController {
+
+    def onPageLoad(): Action[AnyContent] = authAction { _ =>
+      Ok
+    }
+  }
+
+  val mockAuthConnector: AuthConnector = mock[AuthConnector]
+
+  implicit val timeout: Timeout = 5 seconds
+
+  val application: Application = new GuiceApplicationBuilder()
+    .configure(
+      Configuration("metrics.enabled" -> "false", "enrolmentKeys.cbc.key" -> "HMRC-CBC-ORG", "auditing.enabled" -> false)
+    )
+    .overrides(
+      bind[AuthConnector].toInstance(mockAuthConnector)
+    )
+    .build()
+
+  "Identifier Auth Action" when {
+    "the user is not logged in" must {
+      "must return unauthorised" in {
+        when(mockAuthConnector.authorise(any[Predicate](), any[Retrieval[_]]())(any[HeaderCarrier](), any[ExecutionContext]()))
+          .thenReturn(Future.failed(new MissingBearerToken))
+
+        val authAction = application.injector.instanceOf[IdentifierAuthAction]
+        val controller = new Harness(authAction)
+        val result     = controller.onPageLoad()(FakeRequest("", ""))
+        status(result) mustBe UNAUTHORIZED
+
+      }
+      "must return UNAUTHORIZED for not known enrolment" in {
+        val retrieval: RetrievalType =
+          new ~(Enrolments(Set(Enrolment("HMRC-TEST-ORG", Seq(EnrolmentIdentifier("TESTID", "subscriptionID")), "ACTIVE"))), Some(Organisation))
+        when(mockAuthConnector.authorise(any[Predicate](), any[Retrieval[RetrievalType]]())(any[HeaderCarrier](), any[ExecutionContext]()))
+          .thenReturn(Future.successful(retrieval))
+
+        val authAction = application.injector.instanceOf[IdentifierAuthAction]
+        val controller = new Harness(authAction)
+        val result     = controller.onPageLoad()(FakeRequest("", ""))
+        status(result) mustBe UNAUTHORIZED
+      }
+    }
+
+    "the user is logged in" must {
+      "for an Organisation must return the request" in {
+        val retrieval: RetrievalType =
+          new ~(Enrolments(Set(Enrolment("HMRC-CBC-ORG", Seq.empty, "ACTIVE"))), Some(Organisation))
+        when(mockAuthConnector.authorise(any[Predicate](), any[Retrieval[RetrievalType]]())(any[HeaderCarrier](), any[ExecutionContext]()))
+          .thenReturn(Future.successful(retrieval))
+
+        val authAction = application.injector.instanceOf[IdentifierAuthAction]
+        val controller = new Harness(authAction)
+
+        val result = controller.onPageLoad()(FakeRequest("", ""))
+        status(result) mustBe OK
+      }
+
+      "for a Non UK Organisation must return the request" in {
+        val retrieval: RetrievalType =
+          new ~(Enrolments(Set(Enrolment("HMRC-CBC-NONUK-ORG", Seq.empty, "ACTIVE"))), Some(Organisation))
+        when(mockAuthConnector.authorise(any[Predicate](), any[Retrieval[RetrievalType]]())(any[HeaderCarrier](), any[ExecutionContext]()))
+          .thenReturn(Future.successful(retrieval))
+
+        val authAction = application.injector.instanceOf[IdentifierAuthAction]
+        val controller = new Harness(authAction)
+
+        val result = controller.onPageLoad()(FakeRequest("", ""))
+        status(result) mustBe OK
+      }
+
+      "for an Agent must return the request" in {
+        val retrieval: RetrievalType =
+          new ~(Enrolments(Set(Enrolment("HMRC-AS-AGENT", Seq(EnrolmentIdentifier("AgentReferenceNumber", "arn")), "ACTIVE"))), Some(Agent))
+        when(mockAuthConnector.authorise(any[Predicate](), any[Retrieval[RetrievalType]]())(any[HeaderCarrier](), any[ExecutionContext]()))
+          .thenReturn(Future.successful(retrieval))
+
+        val authAction = application.injector.instanceOf[IdentifierAuthAction]
+        val controller = new Harness(authAction)
+
+        val result = controller.onPageLoad()(FakeRequest("", ""))
+        status(result) mustBe OK
+      }
+    }
+  }
+}

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -23,6 +23,7 @@ import models.subscription.request._
 import models.subscription._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
+import uk.gov.hmrc.auth.core.AffinityGroup
 
 import java.time.{LocalDate, LocalDateTime}
 
@@ -275,6 +276,17 @@ trait ModelGenerators {
       for {
         request  <- arbitrary[CreateSubscriptionForCBCRequest]
         response <- arbitrary[CreateSubscriptionResponse]
-      } yield SubscriptionAuditDetails.fromSubscriptionRequestAndResponse(request, response)
+        affinity <- arbitrary[AffinityGroup]
+      } yield SubscriptionAuditDetails.fromSubscriptionRequestAndResponse(request, response, affinity)
     }
+
+  implicit val arbitraryAffinityGroup: Arbitrary[AffinityGroup] = Arbitrary {
+    Gen.oneOf(
+      Seq(
+        AffinityGroup.Organisation,
+        AffinityGroup.Individual,
+        AffinityGroup.Agent
+      )
+    )
+  }
 }


### PR DESCRIPTION
Introduce identifier-based authentication to manage user access based on their role, such as Organisation or Agent. Implement `IdentifierRequest` and `IdentifierAuthAction` for handling authenticated requests, including changes to test cases and configuration settings. Enhance subscription handling by auditing user types and refining enrollment key usage.