### PR TITLE
DAC6-3429: Refactor audit logic

### DIFF
--- a/app/controllers/auth/IdentifierAuthAction.scala
+++ b/app/controllers/auth/IdentifierAuthAction.scala
@@ -21,7 +21,7 @@ import config.AppConfig
 import play.api.http.Status.UNAUTHORIZED
 import play.api.mvc.Results.Status
 import play.api.mvc._
-import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.~

--- a/test/controllers/SubscriptionControllerSpec.scala
+++ b/test/controllers/SubscriptionControllerSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
 import play.api.inject.bind
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.audit.AuditService
@@ -87,13 +87,14 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
         forAll { subscriptionRequest: CreateSubscriptionForCBCRequest =>
           when(mockSubscriptionConnector.sendSubscriptionInformation(mEq(subscriptionRequest))(any[HeaderCarrier], any[ExecutionContext]))
             .thenReturn(Future.successful(HttpResponse(OK, Json.parse("{}"), Map.empty)))
+          when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+            .thenReturn(Future.unit)
 
           val request = FakeRequest(POST, routes.SubscriptionController.createSubscription.url)
             .withJsonBody(Json.toJson(subscriptionRequest))
 
           val result = route(application, request).value
           status(result) mustEqual OK
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -141,6 +142,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -151,7 +155,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual BAD_REQUEST
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -171,6 +174,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -181,7 +187,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual FORBIDDEN
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -201,6 +206,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -211,7 +219,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual SERVICE_UNAVAILABLE
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -235,6 +242,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -245,7 +255,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual INTERNAL_SERVER_ERROR
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -279,6 +288,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -289,7 +301,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual CONFLICT
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -309,6 +320,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -319,7 +333,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual NOT_FOUND
-          verifyZeroInteractions(mockAuditService)
         }
       }
 
@@ -339,6 +352,9 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
             )
           )
 
+        when(mockAuditService.sendAuditEvent(mEq(AuditType.SubscriptionEvent), any[JsValue])(any[HeaderCarrier], any[ExecutionContext]))
+          .thenReturn(Future.unit)
+
         forAll(arbitrary[CreateSubscriptionForCBCRequest]) { subscriptionForCBCRequest =>
           val request =
             FakeRequest(
@@ -349,7 +365,6 @@ class SubscriptionControllerSpec extends SpecBase with BeforeAndAfterEach with G
 
           val result = route(application, request).value
           status(result) mustEqual SERVICE_UNAVAILABLE
-          verifyZeroInteractions(mockAuditService)
         }
       }
     }

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -17,7 +17,7 @@
 package generators
 
 import models._
-import models.audit.SubscriptionAuditDetails
+import models.audit.{SubscriptionAuditDetails, SubscriptionResponseAuditDetails}
 import models.subscription.common._
 import models.subscription.request._
 import models.subscription._
@@ -271,7 +271,7 @@ trait ModelGenerators {
   implicit val arbitraryCreateSubscriptionResponse: Arbitrary[CreateSubscriptionResponse] =
     Arbitrary(arbitrary[CreateSubscriptionForCBCResponse].map(CreateSubscriptionResponse.apply))
 
-  implicit val arbitrarySubscriptionAuditDetails: Arbitrary[SubscriptionAuditDetails] =
+  implicit val arbitrarySubscriptionAuditDetails: Arbitrary[SubscriptionAuditDetails[SubscriptionResponseAuditDetails]] =
     Arbitrary {
       for {
         request  <- arbitrary[CreateSubscriptionForCBCRequest]

--- a/test/models/audit/SubscriptionAuditDetailsSpec.scala
+++ b/test/models/audit/SubscriptionAuditDetailsSpec.scala
@@ -27,10 +27,10 @@ class SubscriptionAuditDetailsSpec extends AnyFreeSpec with Generators with Opti
 
   "SubscriptionAuditDetails" - {
     "must serialise and de-serialise as expected" in {
-      forAll { subscriptionAuditDetails: SubscriptionAuditDetails =>
+      forAll { subscriptionAuditDetails: SubscriptionAuditDetails[SubscriptionResponseAuditDetails] =>
         Json
           .toJson(subscriptionAuditDetails)
-          .as[SubscriptionAuditDetails] mustBe subscriptionAuditDetails
+          .as[SubscriptionAuditDetails[SubscriptionResponseAuditDetails]] mustBe subscriptionAuditDetails
       }
     }
   }


### PR DESCRIPTION
Updated `SubscriptionAuditDetails` to be generic, enabling support for different response types. Refactored the audit flow to handle JSON responses more flexibly and added corresponding updates to tests and generators.