### PR TITLE
DAC6-3727 | updated event structure

### DIFF
--- a/app/models/audit/SubscriptionAuditDetails.scala
+++ b/app/models/audit/SubscriptionAuditDetails.scala
@@ -28,6 +28,7 @@ final case class SubscriptionAuditDetails[T](
   organisationName: String,
   firstContactName: String,
   firstContactEmail: String,
+  hasSecondContact: Boolean,
   firstContactPhoneNumber: Option[String],
   secondContactName: Option[String],
   secondaryContactEmail: Option[String],
@@ -66,13 +67,14 @@ object SubscriptionAuditDetails {
       firstContactName = firstContactInfo._1,
       firstContactEmail = firstContactInfo._2,
       firstContactPhoneNumber = firstContactInfo._3,
+      hasSecondContact = secondContactInfo.isDefined,
       secondContactName = secondContactInfo.map(_._1),
       secondaryContactEmail = secondContactInfo.map(_._2),
       secondContactPhoneNumber = secondContactInfo.flatMap(_._3),
       response = SubscriptionResponseAuditDetails(
         Some(createSubscriptionResponse.responseDetail.subscriptionID),
         createSubscriptionResponse.responseCommon.processingDate,
-        Some(createSubscriptionResponse.responseCommon.status)
+        Option.when(createSubscriptionResponse.responseCommon.status != "OK")(createSubscriptionResponse.responseCommon.status)
       ),
       tradingName = requestDetail.tradingName
     )
@@ -101,6 +103,7 @@ object SubscriptionAuditDetails {
       firstContactName = firstContactInfo._1,
       firstContactEmail = firstContactInfo._2,
       firstContactPhoneNumber = firstContactInfo._3,
+      hasSecondContact = secondContactInfo.isDefined,
       secondContactName = secondContactInfo.map(_._1),
       secondaryContactEmail = secondContactInfo.map(_._2),
       secondContactPhoneNumber = secondContactInfo.flatMap(_._3),

--- a/app/models/audit/SubscriptionResponseAuditDetails.scala
+++ b/app/models/audit/SubscriptionResponseAuditDetails.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 import java.time.LocalDateTime
 
 final case class SubscriptionResponseAuditDetails(
-  subscriptionID: Option[String] = Some("failure"),
+  subscriptionID: Option[String],
   processingDate: LocalDateTime,
   failureMessage: Option[String]
 )


### PR DESCRIPTION
add in hasSecondContact field in audit structure and excluded OK from failureMessage because it uses the status code from the response