### PR TITLE
DAC6-4119-fix| disable Junit plugin that causes issues to pipelines a…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val silencerVersion = "1.7.7"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test,
     Compile / scalafmtOnCompile := true,


### PR DESCRIPTION
…s unable to read coverage xml report properly